### PR TITLE
fix/correct-state-update

### DIFF
--- a/src/hooks/useHabits.jsx
+++ b/src/hooks/useHabits.jsx
@@ -1,20 +1,33 @@
-import { useState, useEffect } from 'react'; 
-export default function useHabits() { 
-const [habits, setHabits] = useState(() => { 
-const stored = localStorage.getItem('habits'); 
-return stored ? JSON.parse(stored) : []; 
-}); [cite: 220] 
-useEffect(() => { 
-localStorage.setItem('habits', JSON.stringify(habits)); 
-}, [habits]); [cite: 221] 
-const addHabit = (title) => { 
-setHabits([...habits, { id: Date.now(), title, done: false }]); 
-}; [cite: 222] 
-const toggleHabit = (id) => { 
-setHabits(habits.map(h => h.id === id ? { ...h, done: !h.done } : h)); 
-}; [cite: 222] 
-const removeHabit = (id) => { 
-setHabits(habits.filter(h => h.id !== id)); 
-}; [cite: 223] 
-return { habits, addHabit, toggleHabit, removeHabit }; 
-} 
+import { useState, useEffect } from 'react';
+
+export default function useHabits() {
+  const [habits, setHabits] = useState(() => {
+    const stored = localStorage.getItem('habits');
+    return stored ? JSON.parse(stored) : [];
+  });
+
+  useEffect(() => {
+    localStorage.setItem('habits', JSON.stringify(habits));
+  }, [habits]);
+
+  const addHabit = (title) => {
+    setHabits((prevHabits) => [
+      ...prevHabits,
+      { id: Date.now(), title, done: false },
+    ]);
+  };
+
+  const toggleHabit = (id) => {
+    setHabits((prevHabits) =>
+      prevHabits.map((h) =>
+        h.id === id ? { ...h, done: !h.done } : h
+      )
+    );
+  };
+
+  const removeHabit = (id) => {
+    setHabits((prevHabits) => prevHabits.filter((h) => h.id !== id));
+  };
+
+  return { habits, addHabit, toggleHabit, removeHabit };
+}


### PR DESCRIPTION
Este PR corrige um bug na atualização do estado dos hábitos, utilizando a função de callback do `setHabits` para garantir o estado anterior mais recente.

Closes #4